### PR TITLE
arowf v.0.7a of July 14-17, 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# minireview
+# arowf
+
+Accuracy Review Of Wikipedias in Flask
 
 Registration-free open source text-based blind review system for
 Accuracy Review of Wikipedias 2016 Google Summer of Code project for
 Wikimedia Foundation.
 
 License: Apache v2 or latest with stronger patent sharing if available.
+
+arowf v.0.7a of July 14-17, 2016


### PR DESCRIPTION
name change from minireview to arowf: Accuracy Review Of Wikipedias in Flask